### PR TITLE
Make _$_ usable with irrelevance and erasure

### DIFF
--- a/src/Function/Base.agda
+++ b/src/Function/Base.agda
@@ -74,9 +74,8 @@ flip f = λ y x → f x y
 -- If you want a left associative infix application operator, use
 -- RawFunctor._<$>_ from Effect.Functor.
 
-_$_ : ∀ {A : Set a} {B : A → Set b} →
-      ((x : A) → B x) → ((x : A) → B x)
-f $ x = f x
+_$_ : A → A
+_$_ f = f
 {-# INLINE _$_ #-}
 
 -- Flipped application (aka pipe-forward)


### PR DESCRIPTION
Functions like `⊥-elim-irr` and `recompute` that take irrelevant or erased arguments cannot be passed to many of the standard library functions. While it is not clear how to generalize something like `flip` or `_∘_` or the various `map` operations in this way without a language-level change, at least `_$_` has an easy and obvious generalization that makes it possible to write `⊥-elim-irr $ long-expression` or `recompute fast-decision $ long-expression` and use it immediately in the current version of Agda.